### PR TITLE
feat: add config.trust_proxy to use x-forwarded-for

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -13,7 +13,7 @@ ttl: 15
 dns:
   port: 53
   ip: 0.0.0.0
-  # Set to true to log hex dumps of every incomming DNS packet (for debugging).
+  # Set to true to log hex dumps of every incoming DNS packet (for debugging).
   #dump_packets: true
 # IP and port the HTTP server runs on
 http:
@@ -27,6 +27,10 @@ https:
 # To disable HTTP and/or HTTPS just set the keys to false instead of the above
 #http: false
 #https: false
+
+# If minidyndns is behind a trusted proxy, and ?myip is not provided, then the the last ip in the
+# X-Forwarded-For header will be used
+trust_proxy: false
 
 # Maximum number of seconds the server waits for clients to send
 # the entire HTTP request (to kill requests from stupid routers that


### PR DESCRIPTION
Hey, great project! It worked very nicely for my use-case. The only thing I _needed_ was the ability to use the forwarded ip if this was running behind a proxy. So, this PR adds a backwards compatible (hopefully) config options to use the forwarded ip provided by the trusted proxy.

I briefly tried running the tests and wasn't able to get them working. If you'd like I can look into that further and try to write some tests for this change. I also haven't written ruby before so feel free to suggest changes/refactor/best-practices/etc. 

I referenced the MDN docs on `X-Forwarded-For` (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For) to ensure that I was using this header correctly.

# Changes
If minidyndns is running behind a proxy, then `connection.peeraddr` is not the true client address. This adds the config `trust_proxy` to indicate that we can trust `X-Forwarded-For`.

The last address is used because it should be added by the trusted proxy. I believe this will only work properly if there is only one proxy. If there are more than one, then we'd have to specify how many, or which proxies to trust, and pick the address the was provided by the first trusted proxy. This is out of the scope of this commit though.